### PR TITLE
Add client credentials auth + full product CRUD tools

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -300,10 +300,38 @@ server.tool(
   {
     title: z.string().min(1),
     descriptionHtml: z.string().optional(),
+    handle: z.string().optional().describe("URL slug. Auto-generated from title if omitted."),
     vendor: z.string().optional(),
     productType: z.string().optional(),
     tags: z.array(z.string()).optional(),
     status: z.enum(["ACTIVE", "DRAFT", "ARCHIVED"]).default("DRAFT"),
+    seo: z
+      .object({
+        title: z.string().optional(),
+        description: z.string().optional(),
+      })
+      .optional()
+      .describe("SEO title and description"),
+    metafields: z
+      .array(
+        z.object({
+          namespace: z.string(),
+          key: z.string(),
+          value: z.string(),
+          type: z.string().describe("e.g. 'single_line_text_field', 'json', 'number_integer'"),
+        })
+      )
+      .optional(),
+    productOptions: z
+      .array(
+        z.object({
+          name: z.string().describe("Option name, e.g. 'Size'"),
+          values: z.array(z.object({ name: z.string() })).optional(),
+        })
+      )
+      .optional()
+      .describe("Product options to create inline (max 3)"),
+    collectionsToJoin: z.array(z.string()).optional().describe("Collection GIDs to add product to"),
   },
   async (args) => {
     const result = await createProduct.execute(args);
@@ -320,10 +348,18 @@ server.tool(
     id: z.string().min(1).describe("Shopify product GID, e.g. gid://shopify/Product/123"),
     title: z.string().optional(),
     descriptionHtml: z.string().optional(),
+    handle: z.string().optional().describe("URL slug for the product"),
     vendor: z.string().optional(),
     productType: z.string().optional(),
     tags: z.array(z.string()).optional(),
     status: z.enum(["ACTIVE", "DRAFT", "ARCHIVED"]).optional(),
+    seo: z
+      .object({
+        title: z.string().optional(),
+        description: z.string().optional(),
+      })
+      .optional()
+      .describe("SEO title and description"),
     metafields: z
       .array(
         z.object({
@@ -335,6 +371,9 @@ server.tool(
         })
       )
       .optional(),
+    collectionsToJoin: z.array(z.string()).optional().describe("Collection GIDs to add product to"),
+    collectionsToLeave: z.array(z.string()).optional().describe("Collection GIDs to remove product from"),
+    redirectNewHandle: z.boolean().optional().describe("If true, old handle redirects to new handle"),
   },
   async (args) => {
     const result = await updateProduct.execute(args);
@@ -354,7 +393,11 @@ server.tool(
         z.object({
           id: z.string().optional().describe("Variant GID for updates. Omit to create new."),
           price: z.string().optional().describe("Price as string, e.g. '49.00'"),
-          sku: z.string().optional(),
+          compareAtPrice: z.string().optional().describe("Compare-at price for showing discounts"),
+          sku: z.string().optional().describe("SKU (mapped to inventoryItem.sku)"),
+          tracked: z.boolean().optional().describe("Whether inventory is tracked. Set false for print-on-demand."),
+          taxable: z.boolean().optional(),
+          barcode: z.string().optional(),
           optionValues: z
             .array(
               z.object({

--- a/src/lib/shopifyAuth.ts
+++ b/src/lib/shopifyAuth.ts
@@ -1,0 +1,129 @@
+/**
+ * Shopify OAuth Client Credentials flow.
+ *
+ * As of January 1 2026 Shopify no longer exposes static Admin API access
+ * tokens in the UI.  New apps created in the Dev Dashboard receive a
+ * client_id + client_secret pair which must be exchanged for a short-lived
+ * access token (expires_in ≈ 86 400 s / 24 h).
+ *
+ * This module handles the token exchange and transparent refresh so the
+ * rest of the codebase can keep using a plain access-token string.
+ */
+
+import type { GraphQLClient } from "graphql-request";
+
+export interface ClientCredentialsConfig {
+  clientId: string;
+  clientSecret: string;
+  shopDomain: string; // e.g. "my-store.myshopify.com"
+}
+
+interface TokenResponse {
+  access_token: string;
+  expires_in: number;
+  scope: string;
+}
+
+// Refresh 5 minutes before actual expiry to avoid race conditions.
+const REFRESH_MARGIN_MS = 5 * 60 * 1000;
+
+export class ShopifyAuth {
+  private config: ClientCredentialsConfig;
+  private accessToken: string | null = null;
+  private expiresAt = 0;
+  private refreshTimer: ReturnType<typeof setTimeout> | null = null;
+  private graphqlClient: GraphQLClient | null = null;
+
+  constructor(config: ClientCredentialsConfig) {
+    this.config = config;
+  }
+
+  /** Attach the GraphQL client so the token can be hot-swapped on refresh. */
+  setGraphQLClient(client: GraphQLClient): void {
+    this.graphqlClient = client;
+  }
+
+  /** Fetch an initial token. Must be called before the server starts. */
+  async initialize(): Promise<string> {
+    await this.fetchToken();
+    this.scheduleRefresh();
+    return this.accessToken!;
+  }
+
+  /** Return the current (valid) access token. */
+  getAccessToken(): string {
+    if (!this.accessToken) {
+      throw new Error("ShopifyAuth not initialized — call initialize() first");
+    }
+    return this.accessToken;
+  }
+
+  /** Stop the background refresh timer (for clean shutdown). */
+  destroy(): void {
+    if (this.refreshTimer) {
+      clearTimeout(this.refreshTimer);
+      this.refreshTimer = null;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal
+  // ---------------------------------------------------------------------------
+
+  private async fetchToken(): Promise<void> {
+    const url = `https://${this.config.shopDomain}/admin/oauth/access_token`;
+
+    const body = new URLSearchParams({
+      grant_type: "client_credentials",
+      client_id: this.config.clientId,
+      client_secret: this.config.clientSecret,
+    });
+
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body,
+    });
+
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(
+        `Shopify token exchange failed (${res.status}): ${text}`
+      );
+    }
+
+    const data = (await res.json()) as TokenResponse;
+    this.accessToken = data.access_token;
+    this.expiresAt = Date.now() + data.expires_in * 1000;
+
+    // Hot-swap the header on the existing GraphQL client so every tool
+    // automatically picks up the new token.
+    if (this.graphqlClient) {
+      this.graphqlClient.setHeader(
+        "X-Shopify-Access-Token",
+        this.accessToken
+      );
+    }
+  }
+
+  private scheduleRefresh(): void {
+    const msUntilRefresh = this.expiresAt - Date.now() - REFRESH_MARGIN_MS;
+    const delay = Math.max(msUntilRefresh, 0);
+
+    this.refreshTimer = setTimeout(async () => {
+      try {
+        await this.fetchToken();
+        this.scheduleRefresh();
+      } catch (err) {
+        console.error("Failed to refresh Shopify access token:", err);
+        // Retry in 60 s rather than dying.
+        this.refreshTimer = setTimeout(() => this.scheduleRefresh(), 60_000);
+      }
+    }, delay);
+
+    // Allow the Node process to exit even if the timer is pending.
+    if (this.refreshTimer && typeof this.refreshTimer === "object" && "unref" in this.refreshTimer) {
+      this.refreshTimer.unref();
+    }
+  }
+}

--- a/src/tools/createProduct.ts
+++ b/src/tools/createProduct.ts
@@ -7,10 +7,44 @@ import { z } from "zod";
 const CreateProductInputSchema = z.object({
   title: z.string().min(1),
   descriptionHtml: z.string().optional(),
+  handle: z.string().optional().describe("URL slug, e.g. 'black-sunglasses'. Auto-generated from title if omitted."),
   vendor: z.string().optional(),
   productType: z.string().optional(),
   tags: z.array(z.string()).optional(),
   status: z.enum(["ACTIVE", "DRAFT", "ARCHIVED"]).default("DRAFT"),
+  seo: z
+    .object({
+      title: z.string().optional(),
+      description: z.string().optional(),
+    })
+    .optional()
+    .describe("SEO title and description for search engines"),
+  metafields: z
+    .array(
+      z.object({
+        namespace: z.string(),
+        key: z.string(),
+        value: z.string(),
+        type: z.string().describe("Metafield type, e.g. 'single_line_text_field', 'json', 'number_integer'"),
+      })
+    )
+    .optional(),
+  productOptions: z
+    .array(
+      z.object({
+        name: z.string().describe("Option name, e.g. 'Size' or 'Color'"),
+        values: z
+          .array(z.object({ name: z.string() }))
+          .optional()
+          .describe("Option values"),
+      })
+    )
+    .optional()
+    .describe("Product options to create inline (max 3)"),
+  collectionsToJoin: z
+    .array(z.string())
+    .optional()
+    .describe("Collection GIDs to add the product to"),
 });
 
 type CreateProductInput = z.infer<typeof CreateProductInputSchema>;
@@ -20,7 +54,7 @@ let shopifyClient: GraphQLClient;
 
 const createProduct = {
   name: "create-product",
-  description: "Create a new product",
+  description: "Create a new product. When using productOptions, Shopify registers all option values but only creates one default variant (first value of each option, price $0). Use manage-product-variants with strategy=REMOVE_STANDALONE_VARIANT afterward to create all real variants with prices.",
   schema: CreateProductInputSchema,
 
   // Add initialize method to set up the GraphQL client
@@ -31,16 +65,36 @@ const createProduct = {
   execute: async (input: CreateProductInput) => {
     try {
       const query = gql`
-        mutation productCreate($input: ProductInput!) {
-          productCreate(input: $input) {
+        mutation productCreate($product: ProductCreateInput!, $media: [CreateMediaInput!]) {
+          productCreate(product: $product, media: $media) {
             product {
               id
               title
+              handle
               descriptionHtml
               vendor
               productType
               status
               tags
+              seo {
+                title
+                description
+              }
+              options {
+                id
+                name
+                values
+              }
+              metafields(first: 10) {
+                edges {
+                  node {
+                    id
+                    namespace
+                    key
+                    value
+                  }
+                }
+              }
             }
             userErrors {
               field
@@ -50,9 +104,14 @@ const createProduct = {
         }
       `;
 
-      const variables = {
-        input,
+      const { media, ...productInput } = input as CreateProductInput & { media?: any[] };
+
+      const variables: Record<string, any> = {
+        product: productInput,
       };
+      if (media?.length) {
+        variables.media = media;
+      }
 
       const data = (await shopifyClient.request(query, variables)) as {
         productCreate: {
@@ -73,7 +132,23 @@ const createProduct = {
         );
       }
 
-      return { product: data.productCreate.product };
+      const product = data.productCreate.product;
+
+      return {
+        product: {
+          id: product.id,
+          title: product.title,
+          handle: product.handle,
+          descriptionHtml: product.descriptionHtml,
+          vendor: product.vendor,
+          productType: product.productType,
+          status: product.status,
+          tags: product.tags,
+          seo: product.seo,
+          options: product.options,
+          metafields: product.metafields?.edges.map((e: any) => e.node) || [],
+        },
+      };
     } catch (error) {
       console.error("Error creating product:", error);
       throw new Error(

--- a/src/tools/deleteProduct.ts
+++ b/src/tools/deleteProduct.ts
@@ -1,0 +1,67 @@
+import type { GraphQLClient } from "graphql-request";
+import { gql } from "graphql-request";
+import { z } from "zod";
+
+// Input schema for deleteProduct
+const DeleteProductInputSchema = z.object({
+  id: z.string().min(1).describe("Shopify product GID, e.g. gid://shopify/Product/123"),
+});
+
+type DeleteProductInput = z.infer<typeof DeleteProductInputSchema>;
+
+// Will be initialized in index.ts
+let shopifyClient: GraphQLClient;
+
+const deleteProduct = {
+  name: "delete-product",
+  description: "Delete a product",
+  schema: DeleteProductInputSchema,
+
+  initialize(client: GraphQLClient) {
+    shopifyClient = client;
+  },
+
+  execute: async (input: DeleteProductInput) => {
+    try {
+      const query = gql`
+        mutation productDelete($input: ProductDeleteInput!) {
+          productDelete(input: $input) {
+            deletedProductId
+            userErrors {
+              field
+              message
+            }
+          }
+        }
+      `;
+
+      const data = (await shopifyClient.request(query, {
+        input: { id: input.id },
+      })) as {
+        productDelete: {
+          deletedProductId: string | null;
+          userErrors: Array<{ field: string; message: string }>;
+        };
+      };
+
+      if (data.productDelete.userErrors.length > 0) {
+        throw new Error(
+          `Failed to delete product: ${data.productDelete.userErrors
+            .map((e) => `${e.field}: ${e.message}`)
+            .join(", ")}`
+        );
+      }
+
+      return { deletedProductId: data.productDelete.deletedProductId };
+    } catch (error) {
+      console.error("Error deleting product:", error);
+      throw new Error(
+        `Failed to delete product: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+    }
+  },
+};
+
+export { deleteProduct };

--- a/src/tools/deleteProductVariants.ts
+++ b/src/tools/deleteProductVariants.ts
@@ -1,0 +1,108 @@
+import type { GraphQLClient } from "graphql-request";
+import { gql } from "graphql-request";
+import { z } from "zod";
+
+// Input schema for deleteProductVariants
+const DeleteProductVariantsInputSchema = z.object({
+  productId: z.string().min(1).describe("Shopify product GID"),
+  variantIds: z.array(z.string().min(1)).min(1).describe("Array of variant GIDs to delete"),
+});
+
+type DeleteProductVariantsInput = z.infer<typeof DeleteProductVariantsInputSchema>;
+
+// Will be initialized in index.ts
+let shopifyClient: GraphQLClient;
+
+const deleteProductVariants = {
+  name: "delete-product-variants",
+  description: "Delete one or more variants from a product",
+  schema: DeleteProductVariantsInputSchema,
+
+  initialize(client: GraphQLClient) {
+    shopifyClient = client;
+  },
+
+  execute: async (input: DeleteProductVariantsInput) => {
+    try {
+      const { productId, variantIds } = input;
+
+      const query = gql`
+        mutation productVariantsBulkDelete(
+          $productId: ID!
+          $variantsIds: [ID!]!
+        ) {
+          productVariantsBulkDelete(
+            productId: $productId
+            variantsIds: $variantsIds
+          ) {
+            product {
+              id
+              title
+              variants(first: 20) {
+                edges {
+                  node {
+                    id
+                    title
+                    price
+                    sku
+                    selectedOptions {
+                      name
+                      value
+                    }
+                  }
+                }
+              }
+            }
+            userErrors {
+              field
+              message
+            }
+          }
+        }
+      `;
+
+      const data = (await shopifyClient.request(query, {
+        productId,
+        variantsIds: variantIds,
+      })) as {
+        productVariantsBulkDelete: {
+          product: any;
+          userErrors: Array<{ field: string; message: string }>;
+        };
+      };
+
+      if (data.productVariantsBulkDelete.userErrors.length > 0) {
+        throw new Error(
+          `Failed to delete variants: ${data.productVariantsBulkDelete.userErrors
+            .map((e) => `${e.field}: ${e.message}`)
+            .join(", ")}`
+        );
+      }
+
+      const product = data.productVariantsBulkDelete.product;
+
+      return {
+        product: {
+          id: product.id,
+          title: product.title,
+          remainingVariants: product.variants.edges.map((e: any) => ({
+            id: e.node.id,
+            title: e.node.title,
+            price: e.node.price,
+            sku: e.node.sku,
+            options: e.node.selectedOptions,
+          })),
+        },
+      };
+    } catch (error) {
+      console.error("Error deleting product variants:", error);
+      throw new Error(
+        `Failed to delete product variants: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+    }
+  },
+};
+
+export { deleteProductVariants };

--- a/src/tools/manageProductOptions.ts
+++ b/src/tools/manageProductOptions.ts
@@ -1,0 +1,289 @@
+import type { GraphQLClient } from "graphql-request";
+import { gql } from "graphql-request";
+import { z } from "zod";
+
+// Input schema for manageProductOptions
+const ManageProductOptionsInputSchema = z.object({
+  productId: z.string().min(1).describe("Shopify product GID"),
+  action: z.enum(["create", "update", "delete"]),
+  // For create
+  options: z
+    .array(
+      z.object({
+        name: z.string().describe("Option name, e.g. 'Size' or 'Color'"),
+        position: z.number().optional().describe("Position of the option (1-based)"),
+        values: z
+          .array(z.string())
+          .optional()
+          .describe("Option values, e.g. ['Small', 'Medium', 'Large']"),
+      })
+    )
+    .optional()
+    .describe("Options to create (action=create)"),
+  // For update
+  optionId: z.string().optional().describe("Option GID to update (action=update)"),
+  name: z.string().optional().describe("New name for the option (action=update)"),
+  position: z.number().optional().describe("New position (action=update)"),
+  valuesToAdd: z
+    .array(z.string())
+    .optional()
+    .describe("Values to add (action=update)"),
+  valuesToDelete: z
+    .array(z.string())
+    .optional()
+    .describe("Value GIDs to delete (action=update)"),
+  // For delete
+  optionIds: z
+    .array(z.string())
+    .optional()
+    .describe("Option GIDs to delete (action=delete)"),
+});
+
+type ManageProductOptionsInput = z.infer<typeof ManageProductOptionsInputSchema>;
+
+// Will be initialized in index.ts
+let shopifyClient: GraphQLClient;
+
+const PRODUCT_OPTIONS_FRAGMENT = gql`
+  fragment ProductOptionsFields on Product {
+    id
+    title
+    options {
+      id
+      name
+      position
+      optionValues {
+        id
+        name
+        hasVariants
+      }
+    }
+    variants(first: 20) {
+      edges {
+        node {
+          id
+          title
+          price
+          selectedOptions {
+            name
+            value
+          }
+        }
+      }
+    }
+  }
+`;
+
+type MutationResponse = {
+  product: any;
+  userErrors: Array<{ field: string; message: string; code?: string }>;
+};
+
+const manageProductOptions = {
+  name: "manage-product-options",
+  description:
+    "Create, update, or delete product options (e.g. Size, Color). Use action='create' to add options, 'update' to rename or add/remove values, 'delete' to remove options.",
+  schema: ManageProductOptionsInputSchema,
+
+  initialize(client: GraphQLClient) {
+    shopifyClient = client;
+  },
+
+  execute: async (input: ManageProductOptionsInput) => {
+    try {
+      const { productId, action } = input;
+
+      if (action === "create") {
+        if (!input.options?.length) {
+          throw new Error("options array is required for action=create");
+        }
+
+        const query = gql`
+          mutation productOptionsCreate(
+            $productId: ID!
+            $options: [OptionCreateInput!]!
+          ) {
+            productOptionsCreate(
+              productId: $productId
+              options: $options
+              variantStrategy: LEAVE_AS_IS
+            ) {
+              product {
+                ...ProductOptionsFields
+              }
+              userErrors {
+                field
+                message
+                code
+              }
+            }
+          }
+          ${PRODUCT_OPTIONS_FRAGMENT}
+        `;
+
+        const options = input.options.map((o) => ({
+          name: o.name,
+          ...(o.position !== undefined && { position: o.position }),
+          ...(o.values && {
+            values: o.values.map((v) => ({ name: v })),
+          }),
+        }));
+
+        const data = (await shopifyClient.request(query, {
+          productId,
+          options,
+        })) as { productOptionsCreate: MutationResponse };
+
+        if (data.productOptionsCreate.userErrors.length > 0) {
+          throw new Error(
+            `Failed to create options: ${data.productOptionsCreate.userErrors
+              .map((e) => `${e.field}: ${e.message}`)
+              .join(", ")}`
+          );
+        }
+
+        return formatProductResponse(data.productOptionsCreate.product);
+      }
+
+      if (action === "update") {
+        if (!input.optionId) {
+          throw new Error("optionId is required for action=update");
+        }
+
+        const query = gql`
+          mutation productOptionUpdate(
+            $productId: ID!
+            $option: OptionUpdateInput!
+            $optionValuesToAdd: [OptionValueCreateInput!]
+            $optionValuesToDelete: [ID!]
+          ) {
+            productOptionUpdate(
+              productId: $productId
+              option: $option
+              optionValuesToAdd: $optionValuesToAdd
+              optionValuesToDelete: $optionValuesToDelete
+            ) {
+              product {
+                ...ProductOptionsFields
+              }
+              userErrors {
+                field
+                message
+                code
+              }
+            }
+          }
+          ${PRODUCT_OPTIONS_FRAGMENT}
+        `;
+
+        const option: Record<string, any> = { id: input.optionId };
+        if (input.name) option.name = input.name;
+        if (input.position !== undefined) option.position = input.position;
+
+        const variables: Record<string, any> = { productId, option };
+        if (input.valuesToAdd?.length) {
+          variables.optionValuesToAdd = input.valuesToAdd.map((v) => ({
+            name: v,
+          }));
+        }
+        if (input.valuesToDelete?.length) {
+          variables.optionValuesToDelete = input.valuesToDelete;
+        }
+
+        const data = (await shopifyClient.request(
+          query,
+          variables
+        )) as { productOptionUpdate: MutationResponse };
+
+        if (data.productOptionUpdate.userErrors.length > 0) {
+          throw new Error(
+            `Failed to update option: ${data.productOptionUpdate.userErrors
+              .map((e) => `${e.field}: ${e.message}`)
+              .join(", ")}`
+          );
+        }
+
+        return formatProductResponse(data.productOptionUpdate.product);
+      }
+
+      if (action === "delete") {
+        if (!input.optionIds?.length) {
+          throw new Error("optionIds array is required for action=delete");
+        }
+
+        const query = gql`
+          mutation productOptionsDelete(
+            $productId: ID!
+            $options: [ID!]!
+          ) {
+            productOptionsDelete(
+              productId: $productId
+              options: $options
+            ) {
+              product {
+                ...ProductOptionsFields
+              }
+              userErrors {
+                field
+                message
+                code
+              }
+            }
+          }
+          ${PRODUCT_OPTIONS_FRAGMENT}
+        `;
+
+        const data = (await shopifyClient.request(query, {
+          productId,
+          options: input.optionIds,
+        })) as { productOptionsDelete: MutationResponse };
+
+        if (data.productOptionsDelete.userErrors.length > 0) {
+          throw new Error(
+            `Failed to delete options: ${data.productOptionsDelete.userErrors
+              .map((e) => `${e.field}: ${e.message}`)
+              .join(", ")}`
+          );
+        }
+
+        return formatProductResponse(data.productOptionsDelete.product);
+      }
+
+      throw new Error(`Unknown action: ${action}`);
+    } catch (error) {
+      console.error("Error managing product options:", error);
+      throw new Error(
+        `Failed to manage product options: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+    }
+  },
+};
+
+function formatProductResponse(product: any) {
+  return {
+    product: {
+      id: product.id,
+      title: product.title,
+      options: product.options.map((o: any) => ({
+        id: o.id,
+        name: o.name,
+        position: o.position,
+        values: o.optionValues.map((v: any) => ({
+          id: v.id,
+          name: v.name,
+          hasVariants: v.hasVariants,
+        })),
+      })),
+      variants: product.variants.edges.map((e: any) => ({
+        id: e.node.id,
+        title: e.node.title,
+        price: e.node.price,
+        options: e.node.selectedOptions,
+      })),
+    },
+  };
+}
+
+export { manageProductOptions };

--- a/src/tools/manageProductVariants.ts
+++ b/src/tools/manageProductVariants.ts
@@ -11,7 +11,11 @@ const VariantOptionSchema = z.object({
 const VariantSchema = z.object({
   id: z.string().optional().describe("Variant GID for updates. Omit to create new."),
   price: z.string().optional().describe("Price as string, e.g. '49.00'"),
+  compareAtPrice: z.string().optional().describe("Compare-at price for showing discounts, e.g. '79.00'"),
   sku: z.string().optional().describe("SKU for the variant (mapped to inventoryItem.sku)"),
+  tracked: z.boolean().optional().describe("Whether inventory is tracked. Set false for print-on-demand."),
+  taxable: z.boolean().optional().describe("Whether the variant is taxable"),
+  barcode: z.string().optional(),
   optionValues: z.array(VariantOptionSchema).optional(),
 });
 
@@ -88,7 +92,14 @@ const manageProductVariants = {
         const createVariants = toCreate.map((v) => {
           const variant: Record<string, any> = {};
           if (v.price) variant.price = v.price;
-          if (v.sku) variant.inventoryItem = { sku: v.sku };
+          if (v.compareAtPrice) variant.compareAtPrice = v.compareAtPrice;
+          if (v.barcode) variant.barcode = v.barcode;
+          if (v.taxable !== undefined) variant.taxable = v.taxable;
+          // sku and tracked both go under inventoryItem
+          const inventoryItem: Record<string, any> = {};
+          if (v.sku) inventoryItem.sku = v.sku;
+          if (v.tracked !== undefined) inventoryItem.tracked = v.tracked;
+          if (Object.keys(inventoryItem).length > 0) variant.inventoryItem = inventoryItem;
           if (v.optionValues) {
             variant.optionValues = v.optionValues.map((ov) => ({
               optionName: ov.optionName,
@@ -159,7 +170,13 @@ const manageProductVariants = {
         const updateVariants = toUpdate.map((v) => {
           const variant: Record<string, any> = { id: v.id };
           if (v.price) variant.price = v.price;
-          if (v.sku) variant.inventoryItem = { sku: v.sku };
+          if (v.compareAtPrice) variant.compareAtPrice = v.compareAtPrice;
+          if (v.barcode) variant.barcode = v.barcode;
+          if (v.taxable !== undefined) variant.taxable = v.taxable;
+          const inventoryItem: Record<string, any> = {};
+          if (v.sku) inventoryItem.sku = v.sku;
+          if (v.tracked !== undefined) inventoryItem.tracked = v.tracked;
+          if (Object.keys(inventoryItem).length > 0) variant.inventoryItem = inventoryItem;
           if (v.optionValues) {
             variant.optionValues = v.optionValues.map((ov) => ({
               optionName: ov.optionName,

--- a/src/tools/manageProductVariants.ts
+++ b/src/tools/manageProductVariants.ts
@@ -1,0 +1,212 @@
+import type { GraphQLClient } from "graphql-request";
+import { gql } from "graphql-request";
+import { z } from "zod";
+
+// Input schema for manageProductVariants
+const VariantOptionSchema = z.object({
+  optionName: z.string().describe("Option name, e.g. 'Size' or 'Color'"),
+  name: z.string().describe("Option value, e.g. '8x10' or 'Black'"),
+});
+
+const VariantSchema = z.object({
+  id: z.string().optional().describe("Variant GID for updates. Omit to create new."),
+  price: z.string().optional().describe("Price as string, e.g. '49.00'"),
+  sku: z.string().optional().describe("SKU for the variant (mapped to inventoryItem.sku)"),
+  optionValues: z.array(VariantOptionSchema).optional(),
+});
+
+const ManageProductVariantsInputSchema = z.object({
+  productId: z.string().min(1).describe("Shopify product GID"),
+  variants: z.array(VariantSchema).min(1).describe("Variants to create or update"),
+  strategy: z
+    .enum(["DEFAULT", "REMOVE_STANDALONE_VARIANT", "PRESERVE_STANDALONE_VARIANT"])
+    .optional()
+    .describe(
+      "Strategy for handling the standalone 'Default Title' variant when creating. DEFAULT removes it automatically."
+    ),
+});
+
+type ManageProductVariantsInput = z.infer<typeof ManageProductVariantsInputSchema>;
+
+// Will be initialized in index.ts
+let shopifyClient: GraphQLClient;
+
+const manageProductVariants = {
+  name: "manage-product-variants",
+  description:
+    "Create or update product variants. Omit variant id to create new, include id to update existing.",
+  schema: ManageProductVariantsInputSchema,
+
+  initialize(client: GraphQLClient) {
+    shopifyClient = client;
+  },
+
+  execute: async (input: ManageProductVariantsInput) => {
+    try {
+      const { productId, variants } = input;
+
+      // Split into creates and updates
+      const toCreate = variants.filter((v) => !v.id);
+      const toUpdate = variants.filter((v) => v.id);
+
+      const results: { created: any[]; updated: any[] } = {
+        created: [],
+        updated: [],
+      };
+
+      // Bulk create new variants
+      if (toCreate.length > 0) {
+        const createQuery = gql`
+          mutation productVariantsBulkCreate(
+            $productId: ID!
+            $variants: [ProductVariantsBulkInput!]!
+            $strategy: ProductVariantsBulkCreateStrategy
+          ) {
+            productVariantsBulkCreate(
+              productId: $productId
+              variants: $variants
+              strategy: $strategy
+            ) {
+              productVariants {
+                id
+                title
+                price
+                sku
+                selectedOptions {
+                  name
+                  value
+                }
+              }
+              userErrors {
+                field
+                message
+              }
+            }
+          }
+        `;
+
+        const createVariants = toCreate.map((v) => {
+          const variant: Record<string, any> = {};
+          if (v.price) variant.price = v.price;
+          if (v.sku) variant.inventoryItem = { sku: v.sku };
+          if (v.optionValues) {
+            variant.optionValues = v.optionValues.map((ov) => ({
+              optionName: ov.optionName,
+              name: ov.name,
+            }));
+          }
+          return variant;
+        });
+
+        const createData = (await shopifyClient.request(createQuery, {
+          productId,
+          variants: createVariants,
+          ...(input.strategy && { strategy: input.strategy }),
+        })) as {
+          productVariantsBulkCreate: {
+            productVariants: any[];
+            userErrors: Array<{ field: string; message: string }>;
+          };
+        };
+
+        if (createData.productVariantsBulkCreate.userErrors.length > 0) {
+          throw new Error(
+            `Failed to create variants: ${createData.productVariantsBulkCreate.userErrors
+              .map((e) => `${e.field}: ${e.message}`)
+              .join(", ")}`
+          );
+        }
+
+        results.created =
+          createData.productVariantsBulkCreate.productVariants.map((v: any) => ({
+            id: v.id,
+            title: v.title,
+            price: v.price,
+            sku: v.sku,
+            options: v.selectedOptions,
+          }));
+      }
+
+      // Bulk update existing variants
+      if (toUpdate.length > 0) {
+        const updateQuery = gql`
+          mutation productVariantsBulkUpdate(
+            $productId: ID!
+            $variants: [ProductVariantsBulkInput!]!
+          ) {
+            productVariantsBulkUpdate(
+              productId: $productId
+              variants: $variants
+            ) {
+              productVariants {
+                id
+                title
+                price
+                sku
+                selectedOptions {
+                  name
+                  value
+                }
+              }
+              userErrors {
+                field
+                message
+              }
+            }
+          }
+        `;
+
+        const updateVariants = toUpdate.map((v) => {
+          const variant: Record<string, any> = { id: v.id };
+          if (v.price) variant.price = v.price;
+          if (v.sku) variant.inventoryItem = { sku: v.sku };
+          if (v.optionValues) {
+            variant.optionValues = v.optionValues.map((ov) => ({
+              optionName: ov.optionName,
+              name: ov.name,
+            }));
+          }
+          return variant;
+        });
+
+        const updateData = (await shopifyClient.request(updateQuery, {
+          productId,
+          variants: updateVariants,
+        })) as {
+          productVariantsBulkUpdate: {
+            productVariants: any[];
+            userErrors: Array<{ field: string; message: string }>;
+          };
+        };
+
+        if (updateData.productVariantsBulkUpdate.userErrors.length > 0) {
+          throw new Error(
+            `Failed to update variants: ${updateData.productVariantsBulkUpdate.userErrors
+              .map((e) => `${e.field}: ${e.message}`)
+              .join(", ")}`
+          );
+        }
+
+        results.updated =
+          updateData.productVariantsBulkUpdate.productVariants.map((v: any) => ({
+            id: v.id,
+            title: v.title,
+            price: v.price,
+            sku: v.sku,
+            options: v.selectedOptions,
+          }));
+      }
+
+      return results;
+    } catch (error) {
+      console.error("Error managing product variants:", error);
+      throw new Error(
+        `Failed to manage product variants: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+    }
+  },
+};
+
+export { manageProductVariants };

--- a/src/tools/updateProduct.ts
+++ b/src/tools/updateProduct.ts
@@ -1,0 +1,143 @@
+import type { GraphQLClient } from "graphql-request";
+import { gql } from "graphql-request";
+import { z } from "zod";
+
+// Input schema for updateProduct
+const UpdateProductInputSchema = z.object({
+  id: z.string().min(1).describe("Shopify product GID, e.g. gid://shopify/Product/123"),
+  title: z.string().optional(),
+  descriptionHtml: z.string().optional(),
+  vendor: z.string().optional(),
+  productType: z.string().optional(),
+  tags: z.array(z.string()).optional(),
+  status: z.enum(["ACTIVE", "DRAFT", "ARCHIVED"]).optional(),
+  metafields: z
+    .array(
+      z.object({
+        id: z.string().optional(),
+        namespace: z.string().optional(),
+        key: z.string().optional(),
+        value: z.string(),
+        type: z.string().optional(),
+      })
+    )
+    .optional(),
+});
+
+type UpdateProductInput = z.infer<typeof UpdateProductInputSchema>;
+
+// Will be initialized in index.ts
+let shopifyClient: GraphQLClient;
+
+const updateProduct = {
+  name: "update-product",
+  description: "Update an existing product's fields (title, description, status, tags, etc.)",
+  schema: UpdateProductInputSchema,
+
+  initialize(client: GraphQLClient) {
+    shopifyClient = client;
+  },
+
+  execute: async (input: UpdateProductInput) => {
+    try {
+      const { id, ...productFields } = input;
+
+      const query = gql`
+        mutation productUpdate($input: ProductInput!) {
+          productUpdate(input: $input) {
+            product {
+              id
+              title
+              descriptionHtml
+              vendor
+              productType
+              status
+              tags
+              metafields(first: 10) {
+                edges {
+                  node {
+                    id
+                    namespace
+                    key
+                    value
+                  }
+                }
+              }
+              variants(first: 20) {
+                edges {
+                  node {
+                    id
+                    title
+                    price
+                    sku
+                    selectedOptions {
+                      name
+                      value
+                    }
+                  }
+                }
+              }
+            }
+            userErrors {
+              field
+              message
+            }
+          }
+        }
+      `;
+
+      const variables = {
+        input: {
+          id,
+          ...productFields,
+        },
+      };
+
+      const data = (await shopifyClient.request(query, variables)) as {
+        productUpdate: {
+          product: any;
+          userErrors: Array<{ field: string; message: string }>;
+        };
+      };
+
+      if (data.productUpdate.userErrors.length > 0) {
+        throw new Error(
+          `Failed to update product: ${data.productUpdate.userErrors
+            .map((e) => `${e.field}: ${e.message}`)
+            .join(", ")}`
+        );
+      }
+
+      const product = data.productUpdate.product;
+
+      return {
+        product: {
+          id: product.id,
+          title: product.title,
+          descriptionHtml: product.descriptionHtml,
+          vendor: product.vendor,
+          productType: product.productType,
+          status: product.status,
+          tags: product.tags,
+          metafields: product.metafields?.edges.map((e: any) => e.node) || [],
+          variants: product.variants?.edges.map((e: any) => ({
+            id: e.node.id,
+            title: e.node.title,
+            price: e.node.price,
+            sku: e.node.sku,
+            options: e.node.selectedOptions,
+          })) || [],
+        },
+      };
+    } catch (error) {
+      console.error("Error updating product:", error);
+      throw new Error(
+        `Failed to update product: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+    }
+  },
+};
+
+export { updateProduct };

--- a/src/tools/updateProduct.ts
+++ b/src/tools/updateProduct.ts
@@ -7,10 +7,18 @@ const UpdateProductInputSchema = z.object({
   id: z.string().min(1).describe("Shopify product GID, e.g. gid://shopify/Product/123"),
   title: z.string().optional(),
   descriptionHtml: z.string().optional(),
+  handle: z.string().optional().describe("URL slug for the product"),
   vendor: z.string().optional(),
   productType: z.string().optional(),
   tags: z.array(z.string()).optional(),
   status: z.enum(["ACTIVE", "DRAFT", "ARCHIVED"]).optional(),
+  seo: z
+    .object({
+      title: z.string().optional(),
+      description: z.string().optional(),
+    })
+    .optional()
+    .describe("SEO title and description for search engines"),
   metafields: z
     .array(
       z.object({
@@ -22,6 +30,9 @@ const UpdateProductInputSchema = z.object({
       })
     )
     .optional(),
+  collectionsToJoin: z.array(z.string()).optional().describe("Collection GIDs to add the product to"),
+  collectionsToLeave: z.array(z.string()).optional().describe("Collection GIDs to remove the product from"),
+  redirectNewHandle: z.boolean().optional().describe("If true, old handle redirects to new handle"),
 });
 
 type UpdateProductInput = z.infer<typeof UpdateProductInputSchema>;
@@ -48,11 +59,16 @@ const updateProduct = {
             product {
               id
               title
+              handle
               descriptionHtml
               vendor
               productType
               status
               tags
+              seo {
+                title
+                description
+              }
               metafields(first: 10) {
                 edges {
                   node {
@@ -114,11 +130,13 @@ const updateProduct = {
         product: {
           id: product.id,
           title: product.title,
+          handle: product.handle,
           descriptionHtml: product.descriptionHtml,
           vendor: product.vendor,
           productType: product.productType,
           status: product.status,
           tags: product.tags,
+          seo: product.seo,
           metafields: product.metafields?.edges.map((e: any) => e.node) || [],
           variants: product.variants?.edges.map((e: any) => ({
             id: e.node.id,


### PR DESCRIPTION
## Summary

- **Client credentials auth** for Dev Dashboard apps (Jan 2026+). Shopify killed static `shpat_` tokens for new apps — this adds automatic token exchange and refresh via `ShopifyAuth` class. Fixes #8.
- **6 new product management tools** bringing the total from 9 to 15, with full CRUD coverage for products, variants, and options.
- **Expanded `create-product`** with handle, SEO, metafields, productOptions, and collectionsToJoin.
- **Updated README** documenting all 15 tools with full parameter reference.

### New tools

| Tool | Description |
|------|-------------|
| `update-product` | Update product fields (title, description, handle, SEO, status, tags, metafields, collections) |
| `delete-product` | Delete a product by GID |
| `manage-product-options` | Create, update, or delete product options (e.g. Size, Color) with value management |
| `manage-product-variants` | Bulk create/update variants with price, compareAtPrice, SKU, inventory tracking, taxable, barcode |
| `delete-product-variants` | Bulk delete variants by GID |

### Key implementation details

- `sku` correctly mapped to `inventoryItem.sku` (not a top-level field on `ProductVariantsBulkInput`)
- `tracked` mapped to `inventoryItem.tracked` for disabling inventory on print-on-demand products
- `strategy` param on variant creation for handling the Default Title variant (`REMOVE_STANDALONE_VARIANT` recommended)
- `productCreate` uses `ProductCreateInput` (not `ProductInput`) with separate `media` arg
- All GraphQL mutations validated against Shopify Admin API schema
- All tools follow existing repo patterns (zod schemas, typed error handling, GraphQL client init)

### Tool coverage

| Resource | Create | Read | Update | Delete |
|----------|--------|------|--------|--------|
| Products | `create-product` | `get-products`, `get-product-by-id` | `update-product` | `delete-product` |
| Options | `manage-product-options` | (via product) | `manage-product-options` | `manage-product-options` |
| Variants | `manage-product-variants` | (via product) | `manage-product-variants` | `delete-product-variants` |
| Orders | — | `get-orders`, `get-order-by-id` | `update-order` | — |
| Customers | — | `get-customers`, `get-customer-orders` | `update-customer` | — |

## Test plan

- [x] End-to-end tested on live Shopify store (create product with handle/SEO/options/metafields → add variants with prices/SKUs/tracked=false → update variant price → update product title/SEO → rename option → delete variant → delete product)
- [x] Client credentials auth verified (token exchange + GraphQL queries)
- [x] Clean TypeScript build (`npm run build`, zero errors)
- [x] All tool schemas validated against Shopify GraphQL Admin API docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)