### PR TITLE
Fix incomplete MetafieldOwnerType enum and add alias normalization

### DIFF
--- a/src/tools/getMetafieldDefinitions.ts
+++ b/src/tools/getMetafieldDefinitions.ts
@@ -3,28 +3,50 @@ import { gql } from "graphql-request";
 import { z } from "zod";
 import { edgesToNodes, handleToolError } from "../lib/toolUtils.js";
 
+/** Map common underscore aliases to their correct Shopify API enum values */
+const OWNER_TYPE_NORMALIZE: Record<string, string> = {
+  PRODUCT_VARIANT: "PRODUCTVARIANT",
+  DRAFT_ORDER: "DRAFTORDER",
+  CART_TRANSFORM: "CARTTRANSFORM",
+};
+
 const GetMetafieldDefinitionsInputSchema = z.object({
   ownerType: z
     .enum([
+      "API_PERMISSION",
       "ARTICLE",
       "BLOG",
+      "CART_TRANSFORM",
+      "CARTTRANSFORM",
       "COLLECTION",
-      "CUSTOMER",
       "COMPANY",
       "COMPANY_LOCATION",
+      "CUSTOMER",
       "DELIVERY_CUSTOMIZATION",
       "DISCOUNT",
+      "DRAFT_ORDER",
       "DRAFTORDER",
+      "FULFILLMENT_CONSTRAINT_RULE",
+      "GIFT_CARD_TRANSACTION",
       "LOCATION",
       "MARKET",
+      "MEDIA_IMAGE",
       "ORDER",
+      "ORDER_ROUTING_LOCATION_RULE",
       "PAGE",
+      "PAYMENT_CUSTOMIZATION",
       "PRODUCT",
+      "PRODUCT_VARIANT",
       "PRODUCTVARIANT",
+      "SELLING_PLAN",
       "SHOP",
+      "VALIDATION",
     ])
     .describe(
-      "The resource type to get metafield definitions for (e.g. PRODUCT, ORDER, CUSTOMER)",
+      "The resource type to get metafield definitions for (e.g. PRODUCT, ORDER, CUSTOMER). " +
+        "Note: Some Shopify types use concatenated names without underscores " +
+        "(PRODUCTVARIANT not PRODUCT_VARIANT, DRAFTORDER not DRAFT_ORDER, CARTTRANSFORM not CART_TRANSFORM). " +
+        "Underscore aliases are accepted and normalized automatically.",
     ),
   first: z
     .number()
@@ -83,7 +105,7 @@ const getMetafieldDefinitions = {
       `;
 
       const variables = {
-        ownerType: input.ownerType,
+        ownerType: OWNER_TYPE_NORMALIZE[input.ownerType] ?? input.ownerType,
         first: input.first ?? 50,
       };
 


### PR DESCRIPTION
The get-metafield-definitions tool rejects valid MetafieldOwnerType values in two ways:
                                                                                                                                                         
  1. Missing enum values — 9 valid Shopify API types (API_PERMISSION, CARTTRANSFORM, FULFILLMENT_CONSTRAINT_RULE, GIFT_CARD_TRANSACTION, MEDIA_IMAGE,    
  ORDER_ROUTING_LOCATION_RULE, PAYMENT_CUSTOMIZATION, SELLING_PLAN, VALIDATION) are not in the Zod schema, causing immediate input validation failures.  
  2. No tolerance for underscore aliases — Shopify uses concatenated names for some types (PRODUCTVARIANT, DRAFTORDER, CARTTRANSFORM), but AI agents and 
  humans naturally produce the underscored form (PRODUCT_VARIANT). This causes API errors that are hard to debug.                                        
   
  Solution                                                                                                                                               
                                                                  
  - Expanded the Zod enum to include all 25 valid Shopify MetafieldOwnerType values plus 3 underscore aliases.                                           
  - Added a normalization map that transparently converts underscore aliases to their correct API values before the GraphQL request.
  - Improved the schema description to document the concatenated naming convention.                                                                      
                                                                  
  Single-file change in src/tools/getMetafieldDefinitions.ts, no new dependencies.